### PR TITLE
Lots of minor enhancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         </repository>
         <repository>
             <id>ess-repo</id>
-            <url>https://ci.ender.zone/plugin/repository/everything/</url>
+            <url>https://repo.essentialsx.net/snapshots/</url>
         </repository>
     </repositories>
     
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -35,9 +35,9 @@
           <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.ess3</groupId>
+            <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsX</artifactId>
-            <version>2.18.1</version>
+            <version>2.19.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <repositories>
         <repository>
             <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
             <id>placeholderapi</id>
@@ -38,6 +38,12 @@
             <groupId>net.essentialsx</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>2.19.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bstats</groupId>
+                    <artifactId>bstats-bukkit</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -186,6 +186,8 @@ public class EssentialsExpansion extends PlaceholderExpansion {
             case "afk_reason":
                 if (user.getAfkMessage() == null) return "";
                 return ChatColor.translateAlternateColorCodes('&', user.getAfkMessage());
+            case "afk_player_count":
+                return String.valueOf(essentials.getUserMap().getAllUniqueUsers().stream().map(UUID -> essentials.getUser(UUID)).filter(User::isAfk).count());
             case "msg_ignore":
                 return user.isIgnoreMsg() ? PlaceholderAPIPlugin.booleanTrue() : PlaceholderAPIPlugin.booleanFalse();
             case "fly":

--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -187,6 +187,8 @@ public class EssentialsExpansion extends PlaceholderExpansion {
                 return String.valueOf(essentials.getSettings().getHomeLimit(user));
             case "jailed":
                 return String.valueOf(user.isJailed());
+            case "jailed_time_remaining":
+                return user.getFormattedJailTime();
             case "pm_recipient":
                 return user.getReplyRecipient() != null ? user.getReplyRecipient().getName() : "";
             case "safe_online":


### PR DESCRIPTION
This PR bumps the EssentialsX version to dev build 2.19, removes bstats from the build, bumps Spigot 1.17, and closes a bunch of issues.

Closes #25, #18.