### PR TITLE
New Placeholder %essentials_world_date_format%

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -288,6 +288,8 @@ public class EssentialsExpansion extends PlaceholderExpansion {
                 return DescParseTickFormat.format12(user.getWorld() == null ? 0 : user.getWorld().getTime());
             case "world_time_24":
                 return DescParseTickFormat.format24(user.getWorld() == null ? 0 : user.getWorld().getTime());
+            case "WORLDDATE":
+                return PlaceholderAPIPlugin.getDateFormat().format(DescParseTickFormat.ticksToDate(user.getWorld() == null ? 0 : user.getWorld().getFullTime()));
         }
         return null;
     }

--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -288,7 +288,7 @@ public class EssentialsExpansion extends PlaceholderExpansion {
                 return DescParseTickFormat.format12(user.getWorld() == null ? 0 : user.getWorld().getTime());
             case "world_time_24":
                 return DescParseTickFormat.format24(user.getWorld() == null ? 0 : user.getWorld().getTime());
-            case "WORLDDATE":
+            case "world_date_format":
                 return PlaceholderAPIPlugin.getDateFormat().format(DescParseTickFormat.ticksToDate(user.getWorld() == null ? 0 : user.getWorld().getFullTime()));
         }
         return null;


### PR DESCRIPTION
Hello! This placeholder is taken works as %essentials_world_date%, but it can be configured freely according to the format in the config.yml of the PAPI plugin.
![image](https://user-images.githubusercontent.com/11898488/127736137-28449e8c-a2fc-4228-bd07-eec18d9b3537.png)

![image](https://user-images.githubusercontent.com/11898488/127736058-08bfe538-bd44-4003-ab65-51c50020184b.png)