### PR TITLE
Remove .5 appending from Home location

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -195,13 +195,13 @@ public class EssentialsExpansion extends PlaceholderExpansion {
 
                     switch (identifier.charAt(identifier.length() - 1)) {
                         case 'x':
-                            stringBuilder.append(home.getX()).append(".5";
+                            stringBuilder.append(home.getX());
                             break;
                         case 'y':
                             stringBuilder.append((int) home.getY());
                             break;
                         case 'z':
-                            stringBuilder.append(home.getZ()).append(".5");
+                            stringBuilder.append(home.getZ());
                             break;
                     }
 


### PR DESCRIPTION
Why was that evene appended to begin with?

Also, if the X one looks weird is it because I accidentally committed directly to master when I wanted to make a PR, so I reverted it (poorly).