### PR TITLE
Added new placeholder %essentials_tp_cooldown%

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -206,7 +206,7 @@ public class EssentialsExpansion extends PlaceholderExpansion {
 
             long diff = TimeUnit.MILLISECONDS.toSeconds(d1 - d2);
 
-            if(diff < cooldown) return "" + (int) (cooldown - diff);
+            if(diff < cooldown) return String.valueOf((int) (cooldown - diff));
 
             return "0";
         }

--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -198,7 +198,7 @@ public class EssentialsExpansion extends PlaceholderExpansion {
 
         if (player == null) return "";
 
-        if (identifier.startsWith("tp_cooldown")) {
+        if (identifier.equals("tp_cooldown")) {
             final double cooldown = essentials.getSettings().getTeleportCooldown();
 
             final long d1 = System.currentTimeMillis();

--- a/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/essentials/EssentialsExpansion.java
@@ -25,7 +25,7 @@ import com.earth2me.essentials.Kit;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.DescParseTickFormat;
-import com.google.common.collect.Streams;
+
 import com.google.common.primitives.Ints;
 import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
@@ -42,7 +42,8 @@ import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.stream.IntStream;
+
+import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
 public class EssentialsExpansion extends PlaceholderExpansion {
@@ -196,6 +197,19 @@ public class EssentialsExpansion extends PlaceholderExpansion {
         }
 
         if (player == null) return "";
+
+        if (identifier.startsWith("tp_cooldown")) {
+            final double cooldown = essentials.getSettings().getTeleportCooldown();
+
+            final long d1 = System.currentTimeMillis();
+            final long d2 = essentials.getUser(player.getUniqueId()).getLastTeleportTimestamp();
+
+            long diff = TimeUnit.MILLISECONDS.toSeconds(d1 - d2);
+
+            if(diff < cooldown) return "" + (int) (cooldown - diff);
+
+            return "0";
+        }
 
         if (identifier.startsWith("kit_last_use_")) {
             String kitName = identifier.split("kit_last_use_")[1].toLowerCase();


### PR DESCRIPTION
You can see **teleport-cooldown** timer.

Example:
![image](https://user-images.githubusercontent.com/18172216/162574165-c7ceb778-6ba0-42c1-a84c-d717db25d8c9.png)

Scoreboard shows the left time for be able to teleport again. (countdown updates every second)